### PR TITLE
Update docker-flow executable

### DIFF
--- a/ansible/roles/docker-flow/tasks/main.yml
+++ b/ansible/roles/docker-flow/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Executable is present
   get_url:
-    url: https://github.com/vfarcic/docker-flow/releases/download/v0.9/docker-flow_linux_amd64
+    url: https://github.com/vfarcic/docker-flow/releases/download/v1.0.2/docker-flow_linux_amd64
     dest: /usr/local/bin/docker-flow
     mode: 0755
 


### PR DESCRIPTION
Tag v0.9 doesn't exist, update to latest release which is v1.0.2